### PR TITLE
Make QNetworkAccessManager owned by unique_ptr

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -18,7 +18,7 @@ ConfigState App::configState;
 App::App(QObject *parent)
     : QObject(parent) {
     initLogger();
-    manager = std::make_unique<QNetworkAccessManager>(this);
+    manager = std::make_unique<QNetworkAccessManager>();
     skipper = std::make_shared<Skipper>();
     configState =  skipper->tryConfig();
     createActions();


### PR DESCRIPTION
 manager 是全局 unique_ptr，同时又把 this（App 对象）设为 Qt parent。退出时发生双重释放：

  1. App 析构 → Qt 对象树删除子对象 QNetworkAccessManager
  2. unique_ptr 析构 → 再次 delete 同一个指针 → crash

  修复：去掉 this parent，让 unique_ptr 独自管理生命周期：