### PR TITLE
Add reliable native disconnect mode and diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ cmake-build-debug
 .idea
 .DS_Store
 build
+dist
+artifacts
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.30)
 project(hearththone_skipper LANGUAGES CXX OBJCXX)
 
 set(CMAKE_CXX_STANDARD 20)
+option(SKIPPER_BUILD_TESTS "Build skipper unit tests" ON)
 
 if (NOT APP_VERSION)    # shallow clone 的情况下无法获取到 tag
     execute_process(
@@ -34,9 +35,11 @@ target_sources(skipper PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/app.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/app_settings.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/clash_config.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/connection_selector.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/config_aware_qeasy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/config_deducer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/local_connection.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/setting_dialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/skipper.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/float_button.cpp
@@ -51,9 +54,11 @@ target_sources(skipper PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/app.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/app_settings.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/clash_config.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/connection_selector.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/config_aware_qeasy.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/config_deducer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/logger.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/local_connection.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/setting_dialog.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/skipper.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/float_button.h
@@ -108,7 +113,8 @@ set(USE_NGHTTP2 OFF)
 set(USE_LIBIDN2 OFF)
 FetchContent_Declare(
         libcurl
-        URL https://curl.se/download/curl-8.17.0.zip
+        URL https://github.com/curl/curl/archive/refs/tags/curl-8_17_0.tar.gz
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 FetchContent_MakeAvailable(yaml-cpp spdlog libcurl)
@@ -118,6 +124,15 @@ target_link_libraries(skipper PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets yaml-cpp s
 target_link_libraries(qcurl PRIVATE Qt6::Core PUBLIC CURL::libcurl)
 
 if (APPLE)
+    add_executable(skipper_native_helper
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/native_pf_helper.cpp
+    )
+    set_target_properties(skipper_native_helper PROPERTIES
+        OUTPUT_NAME "skipper-native-helper"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/skipper.app/Contents/Helpers"
+    )
+    add_dependencies(skipper skipper_native_helper)
+
     qt_add_library(macos_specific STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window_listener.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/include/window_listener.h
@@ -125,18 +140,25 @@ if (APPLE)
     target_compile_options(macos_specific PRIVATE "-fobjc-arc")
     target_include_directories(macos_specific PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     target_link_libraries(macos_specific PRIVATE Qt6::Widgets spdlog "-framework Foundation -framework AppKit")
-    target_link_libraries(skipper PRIVATE macos_specific)
+    target_link_libraries(skipper PRIVATE macos_specific "-framework Security")
 endif ()
 
 install(TARGETS skipper
         BUNDLE DESTINATION .
 )
 
-qt_generate_deploy_app_script(
-        TARGET skipper
-        OUTPUT_SCRIPT deploy_script
-        NO_PLUGINS
-)
+if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    qt_generate_deploy_app_script(
+            TARGET skipper
+            OUTPUT_SCRIPT deploy_script
+            NO_PLUGINS
+    )
+else ()
+    qt_generate_deploy_app_script(
+            TARGET skipper
+            OUTPUT_SCRIPT deploy_script
+    )
+endif ()
 install(SCRIPT ${deploy_script})
 target_compile_definitions(skipper PRIVATE APP_VERSION="${APP_VERSION}")
 
@@ -153,3 +175,28 @@ install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/skipper-install.cmake)
 
 message(STATUS APP_VERSION=${APP_VERSION})
 message(STATUS QT_VERSION=${Qt6_VERSION})
+
+include(CTest)
+if (SKIPPER_BUILD_TESTS)
+    enable_testing()
+    qt_add_executable(connection_selector_test
+        test/connection_selector_test.cpp
+        src/connection_selector.cpp
+        include/connection_selector.h
+    )
+    target_include_directories(connection_selector_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_link_libraries(connection_selector_test PRIVATE Qt6::Core)
+    add_test(NAME connection_selector_test COMMAND connection_selector_test)
+    if (APPLE)
+        qt_add_executable(local_connection_probe
+            test/local_connection_probe.cpp
+            src/local_connection.cpp
+            include/local_connection.h
+        )
+        target_include_directories(local_connection_probe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+        target_link_libraries(local_connection_probe PRIVATE Qt6::Core)
+        add_test(NAME native_helper_rejects_invalid
+                 COMMAND $<TARGET_FILE:skipper_native_helper> disconnect invalid 1119 1500)
+        set_tests_properties(native_helper_rejects_invalid PROPERTIES WILL_FAIL TRUE)
+    endif ()
+endif ()

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 ## HearthStone-Skipper 炉石传说 酒馆战旗 MacOS 一键拔线工具
 
 - 通过点击系统栏快速拔线，帮助您快速跳过战斗动画，获取更多操作时间
-- 利用 clash 核心的能力，系统影响最小化，需要更少权限
+- 可选择 Clash/Mihomo 后端，或完全不依赖 Clash 的 macOS 原生 PF 后端
 - 自由开源，更加安全
 
 ## 如何使用
 
 - 在 release 中下载 app，解压移动到 Application 并打开
-- skipper 需要获取 clash 核心的`external_controller`和`secret`，并且需要 clash 核心接管炉石传说客户端的流量  
+- 在设置的“拔线后端”中选择一种方式：
+  - `macOS 原生 PF（无需 Clash）`：先关闭 Clash/VPN 的 TUN；每次启动通常只需按系统提示授权一次；
+  - Clash TCP/IP 或 UNIX 套接字：需要核心接管炉石流量，并配置控制器。
+- 使用 Clash 后端时，skipper 需要获取 clash 核心的`external_controller`和`secret`，并且需要 clash 核心接管炉石传说客户端的流量。
   skipper 会尝试自动推断`external_controller`和`secret`，如果无法推断，请手动填写
 - 开启 clash 的 tun 模式（或者 clash x pro 的增强模式），保证 clash 核心能够接管到炉石传说客户端的流量
 - 在 clash 配置文件的末尾添加`find-process-mode: always`，保证 clash 核心解析连接发起进程，帮助 skipper 找到炉石传说客户端与对局服务器的连接
@@ -36,20 +39,19 @@
 
 ### 本项目的独特之处/契机
 
-由于 macOS 新内核去除了 ALTQ，过去基于 packet filter 阻塞炉石传说客户端联网的方法已经失效  
-同时，作为替代，新引入的 firewall 没有提供阻塞出站流量的方法。要实现暂时阻塞炉石传说客户端的出站流量，只能依靠预安装某些Network
-Extension
+macOS 已移除 ALTQ，但 PF 的过滤与连接状态控制仍然存在。真正的限制是：macOS 应用防火墙没有提供按应用终止活跃出站连接的公开接口；PF 需要 root 权限、不按进程识别连接，而且仅加载新规则不会自动清除已有连接状态。若要安全集成，还需要签名的特权 helper 或 Network Extension。
 
 然而，这些软件要么支持的功能不足以动态添加规则、终止一个活跃的网络连接，要么是商业付费专有的
 
 本项目使用了一个独特的思路，通过external controller与 clash 核心通信，在 clash 核心内终止炉石传说客户端连接，因此不需要
 root 权限，不修改网络配置，系统影响小
 
+macOS 原生后端通过炉石日志与 `libproc` 双重确认真实对局连接，再由受限辅助程序在独立 PF anchor 中短暂加载精确规则并清除对应状态；完成或失败后都会撤销规则。它不依赖 Clash，但需要 macOS 管理员授权。详细设计和边界见 [非 Clash 原生拔线方案](docs/native-disconnect-design.md)。
+
 同时，这个思路也适用于 windows 端的炉石传说客户端。虽然 windows 端已有广泛使用的 HDT炉石团子
 插件，但需要管理员权限，而且由开源转为闭源，严重违反开源精神
 
 ## 要求
 
-1. 您使用的 clash 核心需要能够接管炉石传说客户端的流量
-2. MacOS（我没有使用任何平台特定功能，略加修改即可运行在 windows）
-
+1. 原生 PF 后端要求 macOS，并需要管理员授权
+2. Clash 后端要求兼容 Clash API 的核心能够接管炉石传说客户端流量

--- a/docs/native-disconnect-design.md
+++ b/docs/native-disconnect-design.md
@@ -1,0 +1,80 @@
+# 非 Clash 原生拔线方案
+
+## 结论
+
+macOS 上可以实现不依赖 Clash 的稳定拔线，但不能由当前这个无特权、临时签名的菜单栏进程直接完成。可发布的实现需要以下两种架构之一：
+
+1. **PF + 特权 helper（已提供测试实现）**：主程序只负责识别炉石连接，受限 helper 经 macOS 管理员授权后短暂加载 PF 规则并清除对应状态。
+2. **Network Extension / System Extension（隔离更精确）**：扩展接管炉石流量，并按来源应用关闭 flow；发布、签名和用户授权成本更高。
+
+直接切 Wi-Fi、杀死游戏进程、每次用 AppleScript 弹管理员密码，或按端口全局封禁都不属于稳定方案。
+
+## 推荐架构
+
+```text
+Qt 菜单栏进程
+  ├─ ConnectionLocator（无特权）
+  │    ├─ libproc 获取 Hearthstone PID/可执行文件路径
+  │    └─ 枚举 ESTABLISHED TCP socket，筛选 1119/3724 与目标 IP
+  └─ NativeDisconnectClient（XPC）
+       └─ 签名的 root helper
+            ├─ 校验调用方 code requirement
+            ├─ 校验 IP、端口和最大阻断时长
+            ├─ 在 com.apple/hearthstone_skipper anchor 加载精确规则
+            ├─ 清除目标地址的现有 PF state
+            └─ 1.0–1.5 秒后清空 anchor 并释放 PF enable token
+```
+
+主程序和 helper 之间只允许结构化请求，例如：
+
+```text
+disconnect(remoteAddress, remotePort, addressFamily, durationMs)
+```
+
+helper 不能提供任意 shell 命令接口。它必须拒绝非 IP 地址、非 1119/3724 端口、过长持续时间以及未通过签名校验的客户端。
+
+## PF 操作时序
+
+1. 使用 `pfctl -E` 获取本次 PF enable reference token，不能粗暴执行全局 `pfctl -e/-d`。
+2. 在系统默认 `com.apple/*` anchor 下创建独立子 anchor，不改写、刷新主 ruleset。
+3. 加载只针对目标地址和端口的 `block drop quick out` 规则，同时覆盖 IPv4/IPv6。
+4. 清除到该目标地址的现有 state。仅添加规则不会影响已经存在的 state。
+5. 保持阻断约 1.0–1.5 秒，让客户端确认掉线并进入重连。
+6. 无论成功、超时、helper 退出或 XPC 断开，都清空子 anchor 并释放 enable token。
+
+macOS 的 `pfctl -k` 只能按地址/网段清 state，不能同时按进程和端口精确删除。因此 PF 版本仍可能短暂影响同一台机器上访问相同远端 IP 的其他连接。游戏服 IP 通常足够专用，但严格的进程级隔离应使用 Network Extension。
+
+## 当前测试实现与正式发布差异
+
+当前测试版在 skipper 进程内保留 macOS Authorization Services 授权并按需运行受限 helper，不安装常驻 root 服务。每次启动通常只需授权一次。helper 只接受合法 IP、端口 1119/3724 和 0.5–3 秒阻断时长，且固定操作自己的 PF anchor。检测到 Clash/VPN 的合成 TUN 地址时会拒绝执行，避免把未生效操作误报为成功。
+
+正式发布仍应使用固定 Team ID、Developer ID 签名、XPC/SMAppService helper、调用方 designated requirement 和完整公证链路，避免每次按需授权并支持安全升级。
+
+## 分阶段实现
+
+### 阶段 1：现有 Clash 后端
+
+- 独立、可测试的连接选择器；
+- 按进程、直连 IP、TCP 和已知游戏端口评分；
+- 瞬时空连接重试；
+- 修正 libcurl/Qt 事件循环和并发请求状态。
+
+### 阶段 2：PF helper（测试版已完成按需授权实现）
+
+- 抽象 `DisconnectBackend`，保留 Clash 作为无特权后端；
+- 用 `libproc` 实现 `ConnectionLocator`，禁止解析 `lsof` 文本；
+- 建立签名的 XPC helper、最小请求协议与崩溃清理；
+- 在 Wi-Fi、以太网、IPv4、IPv6、VPN 并存环境分别做连续测试。
+
+### 阶段 3：Network Extension（可选）
+
+- 需要按来源应用做严格隔离时，再迁移到 System Extension；
+- 保留 PF 后端作为不具备扩展授权时的降级方案。
+
+## 验收标准
+
+- 连续 50 次只关闭炉石对局连接，成功进入重连；
+- 不退出炉石客户端，不中断 Battle.net 登录连接；
+- helper 或主程序被强杀后 2 秒内无残留 PF 规则；
+- 不刷新主 PF ruleset，不影响系统、VPN 或其他防火墙 anchor；
+- 同时覆盖 Wi-Fi/有线网络、IPv4/IPv6，以及休眠唤醒后的首次拔线。

--- a/include/clash_config.h
+++ b/include/clash_config.h
@@ -5,6 +5,7 @@
 enum class ExternalControllerType {
     TCPIP,
     UNIX_DOMAIN,
+    NATIVE,
     NONE
 };
 

--- a/include/connection_selector.h
+++ b/include/connection_selector.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QJsonArray>
+#include <QString>
+#include <optional>
+
+#include "local_connection.h"
+
+struct HearthstoneConnection {
+    QString id;
+    QString process;
+    QString sourceIp;
+    quint16 sourcePort = 0;
+    QString destinationIp;
+    quint16 destinationPort = 0;
+    quint64 traffic = 0;
+    int score = 0;
+};
+
+// Selects one game-server connection without relying on the order returned by
+// the Clash API.  Process ownership and a direct-IP TCP destination are hard
+// requirements; known Blizzard game ports are preferred over generic direct
+// connections.
+[[nodiscard]] std::optional<HearthstoneConnection>
+selectHearthstoneConnection(const QJsonArray &connections);
+
+[[nodiscard]] std::optional<HearthstoneConnection>
+selectHearthstoneConnection(const QJsonArray &connections, const QList<LocalTcpConnection> &localConnections);
+
+[[nodiscard]] std::optional<HearthstoneConnection>
+selectHearthstoneConnection(const QJsonArray &connections, const QList<LocalTcpConnection> &localConnections,
+                            const std::optional<TcpDestination> &gameServer);

--- a/include/local_connection.h
+++ b/include/local_connection.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <optional>
+
+struct TcpDestination {
+    QString ip;
+    quint16 port = 0;
+};
+
+struct LocalTcpConnection {
+    QString process;
+    QString sourceIp;
+    quint16 sourcePort = 0;
+    QString destinationIp;
+    quint16 destinationPort = 0;
+};
+
+// Returns established TCP sockets owned by the local Hearthstone process.
+// On unsupported platforms an empty list is returned; Clash process metadata
+// remains the primary/fallback ownership signal there.
+[[nodiscard]] QList<LocalTcpConnection> hearthstoneTcpConnections();
+
+// Reads the most recent game-server address emitted by Hearthstone itself.
+// This distinguishes the actual match socket from Battle.net service sockets,
+// which may also use Blizzard ports and carry more traffic.
+[[nodiscard]] std::optional<TcpDestination> hearthstoneGameServerDestination();

--- a/include/qcurl.h
+++ b/include/qcurl.h
@@ -17,7 +17,8 @@ class QCurlEasy : public QObject {
 public:
     explicit QCurlEasy(CURL *curl, QObject *parent = nullptr);
     ~QCurlEasy() override;
-    void perform() const;
+    [[nodiscard]] bool perform();
+    [[nodiscard]] bool isRunning() const;
 signals:
     void done(QString error, long code, QByteArray body);
 
@@ -31,6 +32,7 @@ public:
 private:
     QByteArray data = QByteArray();
     char error_buffer[CURL_ERROR_SIZE]{};
+    bool running = false;
 
 };
 

--- a/include/skipper.h
+++ b/include/skipper.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "config_deducer.h"
 #include "spdlog/spdlog.h"
+#include <QElapsedTimer>
 #include <QObject>
 #include <string>
 
@@ -14,7 +15,7 @@ class Skipper : public QObject {
     [[nodiscard]] const ClashConfig &config() const;
     void setConfig(const ClashConfig &config) const;
     void skip();
-    void test() const;
+    void test();
 
   signals:
     void testFinished(bool success, std::string message);
@@ -24,9 +25,17 @@ class Skipper : public QObject {
     void getConnection();
     void handleGetConnectionThenKill(const QString &error, long code, const QByteArray &body);
     void handleKillConnection(const QString &error, long code, const QByteArray &body);
+    void retryGetConnection(const std::string &reason);
+    void finishSkip(bool success);
+    void nativeDisconnect();
+    [[nodiscard]] QString nativeHelperPath() const;
 
   private:
     ConfigAwareQEasy *_qeasy;
     std::shared_ptr<spdlog::logger> _logger;
     bool _busy = false;
+    int _getAttempts = 0;
+    quint64 _skipId = 0;
+    QElapsedTimer _skipTimer;
+    const void *_nativeAuthorization = nullptr;
 };

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -8,6 +8,8 @@
 #include <QMainWindow>
 #include <QDesktopServices>
 #include <QUrl>
+#include <QCoreApplication>
+#include <QSysInfo>
 
 Skipper *App::skipper;
 App *App::_instance = nullptr;
@@ -16,19 +18,24 @@ App *App::_instance = nullptr;
 App::App(QObject *parent) : QObject(parent), trayIcon(nullptr) {
     _instance = this;
     initLogger();
+    const auto startupLogger = spdlog::get("skipper");
+    SPDLOG_LOGGER_INFO(startupLogger, "application_start version={} qt={} os={} arch={} pid={} log={}", APP_VERSION,
+                       QT_VERSION_STR, QSysInfo::prettyProductName().toStdString(),
+                       QSysInfo::currentCpuArchitecture().toStdString(), QCoreApplication::applicationPid(),
+                       getLogFilePath().toStdString());
     if (std::optional clash_config = AppSettings::instance().clash_config(); !clash_config.has_value()) {
-        qeasy = new ConfigAwareQEasy({});
+        qeasy = new ConfigAwareQEasy({}, this);
         auto *deducer = new ConfigDeducer(qeasy, this);
         skipper = new Skipper(qeasy, this);
         deducer->tryDeduce();
-        connect(deducer, &ConfigDeducer::deduceFinished, this, [this](ConfigAwareQEasy *_) {
-            if (qeasy == nullptr) {
+        connect(deducer, &ConfigDeducer::deduceFinished, this, [this](ConfigAwareQEasy *deduced) {
+            if (deduced == nullptr) {
                 return;
             }
             if (settingDialog) {
                 settingDialog->setting_tab->setHitText("skipper 设置已自动推断");
             }
-            AppSettings::instance().clash_config_set(qeasy->config());
+            AppSettings::instance().clash_config_set(deduced->config());
         });
     } else {
         qeasy = new ConfigAwareQEasy(clash_config.value(), this);

--- a/src/app_settings.cpp
+++ b/src/app_settings.cpp
@@ -14,6 +14,9 @@ std::optional<ClashConfig> AppSettings::clash_config() const {
         return {};
     }
     QString external_controller_type = external_controller_type_.toString();
+    if (external_controller_type == "NATIVE") {
+        return std::optional(ClashConfig{.external_controller_type = ExternalControllerType::NATIVE});
+    }
     if (external_controller_type == "UNIX_DOMAIN") {
         // 使用 unix socket 连接 clash 核心，unix_socket 必填
         if (!unix_socket_.isValid() || unix_socket_.toString().isEmpty()) {
@@ -46,6 +49,8 @@ void AppSettings::clash_config_set(const ClashConfig &value) {
         _settings.setValue("external_controller_type", "TCPIP");
     } else if (value.external_controller_type == ExternalControllerType::UNIX_DOMAIN) {
         _settings.setValue("external_controller_type", "UNIX_DOMAIN");
+    } else if (value.external_controller_type == ExternalControllerType::NATIVE) {
+        _settings.setValue("external_controller_type", "NATIVE");
     } else {
         _settings.setValue("external_controller_type", "NONE");
     }

--- a/src/config_aware_qeasy.cpp
+++ b/src/config_aware_qeasy.cpp
@@ -11,6 +11,17 @@ ConfigAwareQEasy::ConfigAwareQEasy(ClashConfig config, QObject *parent) : QCurlE
 ConfigAwareQEasy::~ConfigAwareQEasy() = default;
 
 void ConfigAwareQEasy::test() {
+    SPDLOG_LOGGER_INFO(_logger, "controller_test begin type={} address={} unix_socket={} secret_set={}",
+                       static_cast<int>(_config.external_controller_type), _config.external_controller,
+                       _config.unix_socket, !_config.secret.empty());
+    if (isRunning()) {
+        emit testFinished(false, "skipper正在执行其他网络请求");
+        return;
+    }
+    if (_config.external_controller_type == ExternalControllerType::NONE) {
+        emit testFinished(false, "skipper未完成设置");
+        return;
+    }
     if (_config.external_controller_type == ExternalControllerType::TCPIP && _config.external_controller.empty()) {
         SPDLOG_LOGGER_INFO(_logger, "external controller is empty");
         emit testFinished(false, "skipper未完成设置");
@@ -22,12 +33,16 @@ void ConfigAwareQEasy::test() {
         return;
     }
     curl_easy_setopt(curl, CURLOPT_URL, _config.version().c_str());
+    if (!perform()) {
+        emit testFinished(false, "无法启动检测请求");
+        return;
+    }
     connect(this, &QCurlEasy::done, this, &ConfigAwareQEasy::handle_version_response, Qt::SingleShotConnection);
-    perform();
 }
 
 void ConfigAwareQEasy::handle_version_response(const QString &error, long code, const QByteArray &body) {
-    SPDLOG_LOGGER_INFO(_logger, "/version error={}, code={} response={}", error.toStdString(), code, body.toStdString());
+    SPDLOG_LOGGER_INFO(_logger, "controller_test finish error={} code={} response={}", error.toStdString(), code,
+                       body.toStdString());
     if (!error.isEmpty() || code / 100 != 2) {
 
         emit testFinished(false, fmt::format("/version error={}, code={}", error.toStdString(), code));
@@ -54,7 +69,7 @@ void ConfigAwareQEasy::changeConfig(const ClashConfig &newConfig) {
         curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, _config.unix_socket.c_str());
     }
     if (!_config.secret.empty()) {
-        const std::string header = "Authorization:Bearer " + _config.secret;
+        const std::string header = "Authorization: Bearer " + _config.secret;
         headers = curl_slist_append(nullptr, header.c_str());
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     }

--- a/src/config_deducer.cpp
+++ b/src/config_deducer.cpp
@@ -82,7 +82,11 @@ void ConfigDeducer::startNextTest() {
     case ConfigDeduceState::CLASH_VERGE:
         connect(_qeasy, &ConfigAwareQEasy::testFinished, this, &ConfigDeducer::handleTestFinish);
         _state = ConfigDeduceState::CLASH_FOR_WINDOWS;
+#ifdef Q_OS_MACOS
         deduce_clash_verge();
+#else
+        startNextTest();
+#endif
         break;
     case ConfigDeduceState::CLASH_FOR_WINDOWS:
         _state = ConfigDeduceState::FINISH;

--- a/src/connection_selector.cpp
+++ b/src/connection_selector.cpp
@@ -1,0 +1,139 @@
+#include "connection_selector.h"
+
+#include <QJsonObject>
+#include <utility>
+
+namespace {
+
+bool isHearthstoneProcess(const QJsonObject &metadata, QString *displayName) {
+    QString path = metadata.value("processPath").toString();
+    path.replace('\\', '/');
+    const QString normalizedPath = path.toLower();
+    const QString process = metadata.value("process").toString();
+    const QString normalizedProcess = process.toLower();
+
+    const bool pathMatches =
+        normalizedPath.endsWith("/hearthstone.app/contents/macos/hearthstone") ||
+        normalizedPath.endsWith("/hearthstone.exe");
+    const bool nameMatches = normalizedProcess == "hearthstone" || normalizedProcess == "hearthstone.exe";
+
+    if (displayName != nullptr) {
+        *displayName = path.isEmpty() ? process : path;
+    }
+    return pathMatches || nameMatches;
+}
+
+quint16 portValue(const QJsonValue &value) {
+    bool ok = false;
+    const int port = value.isString() ? value.toString().toInt(&ok) : value.toInt(-1);
+    if (!value.isString()) {
+        ok = port >= 0;
+    }
+    return ok && port > 0 && port <= 65535 ? static_cast<quint16>(port) : 0;
+}
+
+const LocalTcpConnection *matchingLocalConnection(const QJsonObject &metadata,
+                                                   const QList<LocalTcpConnection> &localConnections) {
+    const QString sourceIp = metadata.value("sourceIP").toString();
+    const quint16 sourcePort = portValue(metadata.value("sourcePort"));
+    const QString destinationIp = metadata.value("destinationIP").toString();
+    const quint16 destinationPort = portValue(metadata.value("destinationPort"));
+    if (sourcePort == 0 || destinationPort == 0 || destinationIp.isEmpty()) {
+        return nullptr;
+    }
+
+    for (const LocalTcpConnection &local : localConnections) {
+        const bool sourceIpMatches = sourceIp.isEmpty() || local.sourceIp.isEmpty() || sourceIp == local.sourceIp;
+        if (sourceIpMatches && sourcePort == local.sourcePort && destinationIp == local.destinationIp &&
+            destinationPort == local.destinationPort) {
+            return &local;
+        }
+    }
+    return nullptr;
+}
+
+quint64 nonNegativeInteger(const QJsonValue &value) {
+    const double number = value.toDouble(0);
+    return number > 0 ? static_cast<quint64>(number) : 0;
+}
+
+} // namespace
+
+std::optional<HearthstoneConnection> selectHearthstoneConnection(const QJsonArray &connections) {
+    return selectHearthstoneConnection(connections, {});
+}
+
+std::optional<HearthstoneConnection>
+selectHearthstoneConnection(const QJsonArray &connections, const QList<LocalTcpConnection> &localConnections) {
+    return selectHearthstoneConnection(connections, localConnections, std::nullopt);
+}
+
+std::optional<HearthstoneConnection>
+selectHearthstoneConnection(const QJsonArray &connections, const QList<LocalTcpConnection> &localConnections,
+                            const std::optional<TcpDestination> &gameServer) {
+    std::optional<HearthstoneConnection> best;
+
+    for (const QJsonValue &value : connections) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject connection = value.toObject();
+        const QString id = connection.value("id").toString();
+        const QJsonObject metadata = connection.value("metadata").toObject();
+        QString process;
+
+        const bool clashOwnerMatches = isHearthstoneProcess(metadata, &process);
+        const LocalTcpConnection *localMatch = matchingLocalConnection(metadata, localConnections);
+        if (id.isEmpty() || (!clashOwnerMatches && localMatch == nullptr)) {
+            continue;
+        }
+        if (!clashOwnerMatches) {
+            process = localMatch->process;
+        }
+        const QString network = metadata.value("network").toString().toLower();
+        if (!network.isEmpty() && network != "tcp") {
+            continue;
+        }
+        // A non-empty host represents a domain connection. The game session
+        // itself is connected by IP; killing domain services can exit the
+        // client instead of triggering a game reconnect.
+        if (!metadata.value("host").toString().isEmpty()) {
+            continue;
+        }
+
+        const QString destinationIp = metadata.value("destinationIP").toString();
+        const QString sourceIp = metadata.value("sourceIP").toString();
+        const quint16 sourcePort = portValue(metadata.value("sourcePort"));
+        const quint16 port = portValue(metadata.value("destinationPort"));
+        const bool exactGameServer = gameServer.has_value() && destinationIp == gameServer->ip &&
+                                     port == gameServer->port;
+        // When Hearthstone has declared its active game server, refusing all
+        // other sockets is safer than guessing. In particular, port 1119 is
+        // also used by Battle.net login/services and disconnecting it can
+        // produce a fatal login failure during reconnect.
+        if (gameServer.has_value() && !exactGameServer) {
+            continue;
+        }
+        const int portPreference = port == 3724 ? 200 : (port == 1119 ? 100 : 0);
+        const int score = (localMatch != nullptr ? 300 : 100) + portPreference + (exactGameServer ? 1000 : 0);
+        const quint64 traffic = nonNegativeInteger(connection.value("upload")) +
+                                nonNegativeInteger(connection.value("download"));
+
+        HearthstoneConnection candidate{
+            .id = id,
+            .process = process,
+            .sourceIp = sourceIp,
+            .sourcePort = sourcePort,
+            .destinationIp = destinationIp,
+            .destinationPort = port,
+            .traffic = traffic,
+            .score = score,
+        };
+        if (!best.has_value() || candidate.score > best->score ||
+            (candidate.score == best->score && candidate.traffic > best->traffic)) {
+            best = std::move(candidate);
+        }
+    }
+
+    return best;
+}

--- a/src/float_button.cpp
+++ b/src/float_button.cpp
@@ -83,7 +83,7 @@ void FloatButton::moveToWindow(const QRect &windowRect) {
     move(x, y);
 }
 void FloatButton::onBtnClicked() {
-    SPDLOG_LOGGER_INFO(_logger,"clicked");
+    SPDLOG_LOGGER_INFO(_logger, "float_button_clicked");
     connect(
         App::skipper, &Skipper::skipFinished, this,
         [this](bool success) {

--- a/src/local_connection.cpp
+++ b/src/local_connection.cpp
@@ -1,0 +1,202 @@
+#include "local_connection.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+#if defined(Q_OS_MACOS)
+
+#include <arpa/inet.h>
+#include <libproc.h>
+#include <sys/proc_info.h>
+
+#include <array>
+#include <vector>
+
+namespace {
+
+QString hearthstoneExecutablePath() {
+    const int requiredBytes = proc_listpids(PROC_ALL_PIDS, 0, nullptr, 0);
+    if (requiredBytes <= 0) {
+        return {};
+    }
+    std::vector<pid_t> pids(static_cast<size_t>(requiredBytes / sizeof(pid_t)) + 32);
+    const int pidBytes = proc_listpids(PROC_ALL_PIDS, 0, pids.data(),
+                                      static_cast<int>(pids.size() * sizeof(pid_t)));
+    if (pidBytes <= 0) {
+        return {};
+    }
+    pids.resize(static_cast<size_t>(pidBytes / sizeof(pid_t)));
+    for (const pid_t pid : pids) {
+        if (pid <= 0) {
+            continue;
+        }
+        std::array<char, PROC_PIDPATHINFO_MAXSIZE> pathBuffer{};
+        if (proc_pidpath(pid, pathBuffer.data(), static_cast<uint32_t>(pathBuffer.size())) <= 0) {
+            continue;
+        }
+        QString path = QString::fromUtf8(pathBuffer.data());
+        QString normalized = path;
+        normalized.replace('\\', '/');
+        if (normalized.endsWith("/Hearthstone.app/Contents/MacOS/Hearthstone", Qt::CaseInsensitive)) {
+            return path;
+        }
+    }
+    return {};
+}
+
+QString addressString(const in_sockinfo &info, const bool local) {
+    std::array<char, INET6_ADDRSTRLEN> buffer{};
+    const void *address = nullptr;
+    int family = AF_UNSPEC;
+
+    if ((info.insi_vflag & INI_IPV4) != 0) {
+        family = AF_INET;
+        address = local ? static_cast<const void *>(&info.insi_laddr.ina_46.i46a_addr4)
+                        : static_cast<const void *>(&info.insi_faddr.ina_46.i46a_addr4);
+    } else if ((info.insi_vflag & INI_IPV6) != 0) {
+        family = AF_INET6;
+        address = local ? static_cast<const void *>(&info.insi_laddr.ina_6)
+                        : static_cast<const void *>(&info.insi_faddr.ina_6);
+    }
+
+    return address != nullptr && inet_ntop(family, address, buffer.data(), buffer.size()) != nullptr
+               ? QString::fromLatin1(buffer.data())
+               : QString{};
+}
+
+bool isHearthstoneExecutable(const QString &path) {
+    QString normalized = path;
+    normalized.replace('\\', '/');
+    return normalized.endsWith("/Hearthstone.app/Contents/MacOS/Hearthstone", Qt::CaseInsensitive);
+}
+
+} // namespace
+
+QList<LocalTcpConnection> hearthstoneTcpConnections() {
+    QList<LocalTcpConnection> result;
+    const int requiredBytes = proc_listpids(PROC_ALL_PIDS, 0, nullptr, 0);
+    if (requiredBytes <= 0) {
+        return result;
+    }
+
+    // Leave spare capacity for processes created between the size and data
+    // calls. proc_listpids returns a byte count rather than an element count.
+    std::vector<pid_t> pids(static_cast<size_t>(requiredBytes / sizeof(pid_t)) + 32);
+    const int pidBytes = proc_listpids(PROC_ALL_PIDS, 0, pids.data(),
+                                      static_cast<int>(pids.size() * sizeof(pid_t)));
+    if (pidBytes <= 0) {
+        return result;
+    }
+    pids.resize(static_cast<size_t>(pidBytes / sizeof(pid_t)));
+
+    for (const pid_t pid : pids) {
+        if (pid <= 0) {
+            continue;
+        }
+        std::array<char, PROC_PIDPATHINFO_MAXSIZE> pathBuffer{};
+        if (proc_pidpath(pid, pathBuffer.data(), static_cast<uint32_t>(pathBuffer.size())) <= 0) {
+            continue;
+        }
+        const QString processPath = QString::fromUtf8(pathBuffer.data());
+        if (!isHearthstoneExecutable(processPath)) {
+            continue;
+        }
+
+        const int requiredFdBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nullptr, 0);
+        if (requiredFdBytes <= 0) {
+            continue;
+        }
+        std::vector<proc_fdinfo> fds(static_cast<size_t>(requiredFdBytes / sizeof(proc_fdinfo)) + 16);
+        const int fdBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fds.data(),
+                                        static_cast<int>(fds.size() * sizeof(proc_fdinfo)));
+        if (fdBytes <= 0) {
+            continue;
+        }
+        fds.resize(static_cast<size_t>(fdBytes / sizeof(proc_fdinfo)));
+
+        for (const proc_fdinfo &fd : fds) {
+            if (fd.proc_fdtype != PROX_FDTYPE_SOCKET) {
+                continue;
+            }
+            socket_fdinfo socket{};
+            const int socketBytes = proc_pidfdinfo(pid, fd.proc_fd, PROC_PIDFDSOCKETINFO, &socket,
+                                                   static_cast<int>(sizeof(socket)));
+            if (socketBytes != sizeof(socket) || socket.psi.soi_kind != SOCKINFO_TCP) {
+                continue;
+            }
+            const tcp_sockinfo &tcp = socket.psi.soi_proto.pri_tcp;
+            if (tcp.tcpsi_state != TSI_S_ESTABLISHED) {
+                continue;
+            }
+            const in_sockinfo &info = tcp.tcpsi_ini;
+            const quint16 sourcePort = ntohs(static_cast<uint16_t>(info.insi_lport));
+            const quint16 destinationPort = ntohs(static_cast<uint16_t>(info.insi_fport));
+            if (sourcePort == 0 || destinationPort == 0) {
+                continue;
+            }
+            result.append({
+                .process = processPath,
+                .sourceIp = addressString(info, true),
+                .sourcePort = sourcePort,
+                .destinationIp = addressString(info, false),
+                .destinationPort = destinationPort,
+            });
+        }
+    }
+    return result;
+}
+
+std::optional<TcpDestination> hearthstoneGameServerDestination() {
+    QString executablePath = hearthstoneExecutablePath();
+    executablePath.replace('\\', '/');
+    const qsizetype bundlePosition = executablePath.indexOf("/Hearthstone.app/", 0, Qt::CaseInsensitive);
+    if (bundlePosition < 0) {
+        return std::nullopt;
+    }
+
+    const QDir logsDir(executablePath.left(bundlePosition) + "/Logs");
+    const QFileInfoList sessions = logsDir.entryInfoList({"Hearthstone_*"}, QDir::Dirs | QDir::NoDotAndDotDot,
+                                                         QDir::Time);
+    if (sessions.isEmpty()) {
+        return std::nullopt;
+    }
+    static const QRegularExpression addressPattern(
+        R"(Network\.GotoGameServe\(\) - address=\s*(.+):(\d+),\s*game=)");
+    // Only the newest client session is valid. Falling back to an older log
+    // after a restart could turn a stale game address into a false positive.
+    QFile file(sessions.constFirst().absoluteFilePath() + "/GameNetLogger.log");
+    if (!file.open(QIODevice::ReadOnly)) {
+        return std::nullopt;
+    }
+    constexpr qint64 tailBytes = 128 * 1024;
+    if (file.size() > tailBytes) {
+        file.seek(file.size() - tailBytes);
+    }
+    const QList<QByteArray> lines = file.readAll().split('\n');
+    for (auto line = lines.crbegin(); line != lines.crend(); ++line) {
+        const QRegularExpressionMatch match = addressPattern.match(QString::fromUtf8(*line));
+        if (!match.hasMatch()) {
+            continue;
+        }
+        bool ok = false;
+        const int port = match.captured(2).toInt(&ok);
+        if (ok && port > 0 && port <= 65535) {
+            return TcpDestination{.ip = match.captured(1).trimmed(), .port = static_cast<quint16>(port)};
+        }
+    }
+    return std::nullopt;
+}
+
+#else
+
+QList<LocalTcpConnection> hearthstoneTcpConnections() {
+    return {};
+}
+
+std::optional<TcpDestination> hearthstoneGameServerDestination() {
+    return std::nullopt;
+}
+
+#endif

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,10 +1,10 @@
 #include "logger.h"
 
-#include <QStandardPaths>
 #include <QDir>
+#include <QStandardPaths>
+#include "spdlog/sinks/dist_sink.h"
 #include "spdlog/sinks/rotating_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
-#include "spdlog/sinks/dist_sink.h"
 
 
 static QString initLogFilePath() {
@@ -30,8 +30,8 @@ void initLogger() {
     // 输出到日志文件
     auto regular_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
         initLogFilePath().toStdString(),
-        1024 * 4,
-        1
+        1024 * 1024 * 2,
+        3
         );
 #ifdef SKIPPER_DEBUG
     // debug 时彩色的终端日志
@@ -46,5 +46,7 @@ void initLogger() {
     auto logger = std::make_shared<spdlog::logger>("skipper", regular_sink);
 #endif
     spdlog::register_logger(logger);
-    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%l] [%@] %v");
+    logger->set_level(spdlog::level::info);
+    logger->flush_on(spdlog::level::info);
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%n] [%l] [%@] %v");
 }

--- a/src/native_pf_helper.cpp
+++ b/src/native_pf_helper.cpp
@@ -1,0 +1,215 @@
+#include <arpa/inet.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr const char *kPfctl = "/sbin/pfctl";
+constexpr const char *kAnchor = "com.apple/hearthstone_skipper";
+
+struct CommandResult {
+    int exitCode = -1;
+    std::string output;
+};
+
+CommandResult runPfctl(const std::vector<std::string> &arguments, const std::string &input = {}) {
+    int inputPipe[2]{};
+    int outputPipe[2]{};
+    if (pipe(inputPipe) != 0 || pipe(outputPipe) != 0) {
+        return {.exitCode = -1, .output = std::string("pipe failed: ") + std::strerror(errno)};
+    }
+
+    const pid_t pid = fork();
+    if (pid < 0) {
+        close(inputPipe[0]);
+        close(inputPipe[1]);
+        close(outputPipe[0]);
+        close(outputPipe[1]);
+        return {.exitCode = -1, .output = std::string("fork failed: ") + std::strerror(errno)};
+    }
+    if (pid == 0) {
+        dup2(inputPipe[0], STDIN_FILENO);
+        dup2(outputPipe[1], STDOUT_FILENO);
+        dup2(outputPipe[1], STDERR_FILENO);
+        close(inputPipe[0]);
+        close(inputPipe[1]);
+        close(outputPipe[0]);
+        close(outputPipe[1]);
+
+        std::vector<char *> argv;
+        argv.reserve(arguments.size() + 2);
+        argv.push_back(const_cast<char *>(kPfctl));
+        for (const std::string &argument : arguments) {
+            argv.push_back(const_cast<char *>(argument.c_str()));
+        }
+        argv.push_back(nullptr);
+        execv(kPfctl, argv.data());
+        _exit(127);
+    }
+
+    close(inputPipe[0]);
+    close(outputPipe[1]);
+    size_t written = 0;
+    while (written < input.size()) {
+        const ssize_t count = write(inputPipe[1], input.data() + written, input.size() - written);
+        if (count <= 0) {
+            break;
+        }
+        written += static_cast<size_t>(count);
+    }
+    close(inputPipe[1]);
+
+    CommandResult result;
+    std::array<char, 4096> buffer{};
+    ssize_t count = 0;
+    while ((count = read(outputPipe[0], buffer.data(), buffer.size())) > 0) {
+        result.output.append(buffer.data(), static_cast<size_t>(count));
+    }
+    close(outputPipe[0]);
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) == pid && WIFEXITED(status)) {
+        result.exitCode = WEXITSTATUS(status);
+    }
+    return result;
+}
+
+bool validAddress(const std::string &address, int *family) {
+    std::array<unsigned char, sizeof(in6_addr)> binary{};
+    if (inet_pton(AF_INET, address.c_str(), binary.data()) == 1) {
+        *family = AF_INET;
+        return true;
+    }
+    if (inet_pton(AF_INET6, address.c_str(), binary.data()) == 1) {
+        *family = AF_INET6;
+        return true;
+    }
+    return false;
+}
+
+bool parseNumber(const char *text, int minimum, int maximum, int *result) {
+    try {
+        size_t consumed = 0;
+        const int value = std::stoi(text, &consumed);
+        if (consumed != std::strlen(text) || value < minimum || value > maximum) {
+            return false;
+        }
+        *result = value;
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+void clearAnchor() {
+    runPfctl({"-a", kAnchor, "-F", "rules"});
+}
+
+bool blockedPacketSeen() {
+    const CommandResult labels = runPfctl({"-a", kAnchor, "-s", "labels"});
+    if (labels.exitCode != 0) {
+        return false;
+    }
+    std::istringstream lines(labels.output);
+    std::string line;
+    while (std::getline(lines, line)) {
+        std::istringstream fields(line);
+        std::string label;
+        unsigned long long evaluations = 0;
+        unsigned long long packets = 0;
+        if (fields >> label >> evaluations >> packets && label == "hearthstone_skipper" && packets > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    if (argc != 5 || std::string(argv[1]) != "disconnect") {
+        std::cerr << "usage: skipper-native-helper disconnect <ip> <port> <duration-ms>\n";
+        return 64;
+    }
+
+    const std::string address = argv[2];
+    int family = AF_UNSPEC;
+    int port = 0;
+    int durationMs = 0;
+    if (!validAddress(address, &family) || !parseNumber(argv[3], 1, 65535, &port) ||
+        (port != 1119 && port != 3724) || !parseNumber(argv[4], 500, 3000, &durationMs)) {
+        std::cerr << "request rejected: invalid address, Blizzard port, or duration\n";
+        return 65;
+    }
+    if (geteuid() != 0) {
+        std::cerr << "administrator privileges are required\n";
+        return 77;
+    }
+
+    const CommandResult enable = runPfctl({"-E"});
+    if (enable.exitCode != 0) {
+        std::cerr << "pf enable failed: " << enable.output;
+        return 70;
+    }
+    std::smatch tokenMatch;
+    const std::regex tokenPattern(R"(Token\s*:\s*(\d+))", std::regex::icase);
+    if (!std::regex_search(enable.output, tokenMatch, tokenPattern)) {
+        std::cerr << "pf enable token missing: " << enable.output;
+        return 70;
+    }
+    const std::string token = tokenMatch[1].str();
+    const auto cleanup = [&token] {
+        clearAnchor();
+        runPfctl({"-X", token});
+    };
+
+    const std::string familyName = family == AF_INET ? "inet" : "inet6";
+    // Match ACK-bearing packets from the established connection, but never
+    // the SYN used by Hearthstone's immediate reconnect. This avoids the
+    // reconnect loop being poisoned by a second synthetic RST/refusal.
+    const std::string rule = "block return-rst out quick " + familyName + " proto tcp to " + address +
+                             " port = " + std::to_string(port) +
+                             " flags A/A label hearthstone_skipper\n";
+    const CommandResult load = runPfctl({"-a", kAnchor, "-f", "-"}, rule);
+    if (load.exitCode != 0) {
+        cleanup();
+        std::cerr << "pf rule load failed: " << load.output;
+        return 70;
+    }
+
+    const std::string wildcard = family == AF_INET ? "0.0.0.0/0" : "::/0";
+    const CommandResult kill = runPfctl({"-k", wildcard, "-k", address});
+    if (kill.exitCode != 0) {
+        cleanup();
+        std::cerr << "pf state removal failed: " << kill.output;
+        return 70;
+    }
+
+    int elapsedMs = 0;
+    constexpr int pollIntervalMs = 10;
+    bool triggered = blockedPacketSeen();
+    while (elapsedMs < durationMs && !triggered) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(pollIntervalMs));
+        elapsedMs += pollIntervalMs;
+        triggered = blockedPacketSeen();
+    }
+    cleanup();
+    if (!triggered) {
+        std::cerr << "native disconnect timed out before the established connection emitted a packet\n";
+        return 69;
+    }
+    std::cout << "native disconnect completed destination=" << address << ':' << port
+              << " observed_after_ms=" << elapsedMs << '\n';
+    return 0;
+}

--- a/src/qcurl.cpp
+++ b/src/qcurl.cpp
@@ -1,6 +1,7 @@
 #include "qcurl.h"
 #include <QSocketNotifier>
-#include <iostream>
+#include <QTimer>
+#include <cstring>
 
 [[maybe_unused]] int curl_init_code = curl_global_init(CURL_GLOBAL_ALL);
 
@@ -18,10 +19,27 @@ QCurlEasy::QCurlEasy(CURL *curl, QObject *parent) : QObject(parent), curl(curl) 
                      });
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 750L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 2500L);
 }
 
-void QCurlEasy::perform() const {
-    curl_multi_add_handle(QCurl::instance()._curlm, curl);
+bool QCurlEasy::perform() {
+    if (running) {
+        return false;
+    }
+    data.clear();
+    memset(error_buffer, 0, sizeof(error_buffer));
+    const CURLMcode code = curl_multi_add_handle(QCurl::instance()._curlm, curl);
+    if (code != CURLM_OK) {
+        return false;
+    }
+    running = true;
+    return true;
+}
+
+bool QCurlEasy::isRunning() const {
+    return running;
 }
 
 QCurlEasy::~QCurlEasy() {
@@ -33,10 +51,11 @@ QCurlEasy::~QCurlEasy() {
 
 
 void QCurlEasy::emit_done(CURLcode curl_code) {
+    running = false;
     QString error;
-    if (curl_code != CURLE_OK || error_buffer[0] != 0) {
-        error = QString(error_buffer);
-        memset(&error_buffer, 0, sizeof(error_buffer));
+    if (curl_code != CURLE_OK) {
+        error = error_buffer[0] != 0 ? QString::fromUtf8(error_buffer)
+                                     : QString::fromUtf8(curl_easy_strerror(curl_code));
     }
     long http_code;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
@@ -46,6 +65,7 @@ void QCurlEasy::emit_done(CURLcode curl_code) {
 
 
 QCurl::QCurl(QObject *parent) : QObject(parent), _timer(new QTimer(this)) {
+    _timer->setSingleShot(true);
     _curlm = curl_multi_init();
     curl_multi_setopt(_curlm, CURLMOPT_SOCKETFUNCTION, socket_callback);
     curl_multi_setopt(_curlm, CURLMOPT_SOCKETDATA, this);
@@ -54,8 +74,6 @@ QCurl::QCurl(QObject *parent) : QObject(parent), _timer(new QTimer(this)) {
 
     // 连接 timer 到 socket_action
     connect(_timer, &QTimer::timeout, this, [this] {
-        int running_handles;
-        curl_multi_socket_action(_curlm, CURL_SOCKET_TIMEOUT, 0, &running_handles);
         handleSocketAction(nullptr, CURL_SOCKET_TIMEOUT, 0);
     });
 }
@@ -85,12 +103,12 @@ int QCurl::timer_callback(CURLM *, long timeout_ms, QCurl *qcurl) {
     if (timeout_ms < 0) {
         qcurl->_timer->stop();
     } else {
-        qcurl->_timer->start((int)timeout_ms);
+        qcurl->_timer->start(static_cast<int>(timeout_ms));
     }
     return 0;
 }
 
-int QCurl::socket_callback(CURL *easy, curl_socket_t s, int what, QCurl *qcurl, SocketNotifiers *notifiers) {
+int QCurl::socket_callback(CURL *, curl_socket_t s, int what, QCurl *qcurl, SocketNotifiers *notifiers) {
     // 此 socket 初次出现，加入 qt 事件循环中监听 socket 事件
     if ((what == CURL_POLL_IN || what == CURL_POLL_INOUT) && (
             notifiers == nullptr || notifiers->read_notifier == nullptr)) {
@@ -101,8 +119,8 @@ int QCurl::socket_callback(CURL *easy, curl_socket_t s, int what, QCurl *qcurl, 
         notifiers->read_notifier = new QSocketNotifier(static_cast<qintptr>(s), QSocketNotifier::Read, qcurl);
 
         // socket 事件发生，通知 libcurl
-        connect(notifiers->read_notifier, &QSocketNotifier::activated, qcurl, [easy,qcurl, s]() {
-            qcurl->handleSocketAction(easy, s, CURL_CSELECT_IN);
+        connect(notifiers->read_notifier, &QSocketNotifier::activated, qcurl, [qcurl, s]() {
+            qcurl->handleSocketAction(nullptr, s, CURL_CSELECT_IN);
         });
     }
     if ((what == CURL_POLL_OUT || what == CURL_POLL_INOUT) && (
@@ -113,15 +131,15 @@ int QCurl::socket_callback(CURL *easy, curl_socket_t s, int what, QCurl *qcurl, 
         }
         notifiers->write_notifier = new QSocketNotifier(static_cast<qintptr>(s), QSocketNotifier::Write, qcurl);
 
-        connect(notifiers->write_notifier, &QSocketNotifier::activated, qcurl, [easy,qcurl, s]() {
-            qcurl->handleSocketAction(easy, s, CURL_CSELECT_OUT);
+        connect(notifiers->write_notifier, &QSocketNotifier::activated, qcurl, [qcurl, s]() {
+            qcurl->handleSocketAction(nullptr, s, CURL_CSELECT_OUT);
         });
     }
-    if (what == CURL_POLL_IN && notifiers->write_notifier != nullptr) {
-        notifiers->write_notifier->setEnabled(false);
+    if (notifiers != nullptr && notifiers->read_notifier != nullptr) {
+        notifiers->read_notifier->setEnabled(what == CURL_POLL_IN || what == CURL_POLL_INOUT);
     }
-    if (what == CURL_POLL_OUT && notifiers->read_notifier != nullptr) {
-        notifiers->read_notifier->setEnabled(true);
+    if (notifiers != nullptr && notifiers->write_notifier != nullptr) {
+        notifiers->write_notifier->setEnabled(what == CURL_POLL_OUT || what == CURL_POLL_INOUT);
     }
     if (what == CURL_POLL_REMOVE && notifiers != nullptr) {
         curl_multi_assign(qcurl->_curlm, s, nullptr);

--- a/src/setting_dialog.cpp
+++ b/src/setting_dialog.cpp
@@ -32,11 +32,11 @@ SettingDialog::SettingDialog() : setting_tab(new SettingTab), about_tab(new Abou
 
 SettingDialog::~SettingDialog() = default;
 
-SettingTab::SettingTab(QWidget *parent) : QWidget(parent), _config(App::skipper->config()), timer(new QTimer(parent)) {
+SettingTab::SettingTab(QWidget *parent) : QWidget(parent), _config(App::skipper->config()), timer(new QTimer(this)) {
     layout_outer = new QVBoxLayout(this);
 
     // ===== 必要配置 =====
-    clash_group = new QGroupBox("必要配置", this);
+    clash_group = new QGroupBox("拔线方式", this);
     clash_group->setAlignment(Qt::AlignHCenter);
     static const char groupBoxStyle[] =
         "QGroupBox {"
@@ -57,13 +57,17 @@ SettingTab::SettingTab(QWidget *parent) : QWidget(parent), _config(App::skipper-
 
     constexpr int IDX_TCPIP = 0;
     constexpr int IDX_UNIX = 1;
+    constexpr int IDX_NATIVE = 2;
     external_controller_type_edit = new QComboBox(this);
     external_controller_type_edit->addItem("TCP/IP", "TCPIP");
     external_controller_type_edit->addItem("UNIX套接字", "UNIX_DOMAIN");
+    external_controller_type_edit->addItem("macOS 原生 PF（无需 Clash）", "NATIVE");
     if (_config.external_controller_type == ExternalControllerType::TCPIP) {
         external_controller_type_edit->setCurrentIndex(IDX_TCPIP);
     } else if (_config.external_controller_type == ExternalControllerType::UNIX_DOMAIN) {
         external_controller_type_edit->setCurrentIndex(IDX_UNIX);
+    } else if (_config.external_controller_type == ExternalControllerType::NATIVE) {
+        external_controller_type_edit->setCurrentIndex(IDX_NATIVE);
     }
 
     external_controller_edit = new QLineEdit(QString::fromStdString(_config.external_controller), this);
@@ -89,6 +93,8 @@ SettingTab::SettingTab(QWidget *parent) : QWidget(parent), _config(App::skipper-
             _config.external_controller_type = ExternalControllerType::TCPIP;
         } else if (index == IDX_UNIX) {
             _config.external_controller_type = ExternalControllerType::UNIX_DOMAIN;
+        } else if (index == IDX_NATIVE) {
+            _config.external_controller_type = ExternalControllerType::NATIVE;
         }
         onFormComplete();
         setupVisibility();
@@ -98,13 +104,18 @@ SettingTab::SettingTab(QWidget *parent) : QWidget(parent), _config(App::skipper-
     test_btn->setMaximumWidth(80);
 
     connect(test_btn, &QPushButton::clicked, this, &SettingTab::onTestBtnClicked);
-    form_layout->addRow("外部控制器类型", external_controller_type_edit);
+    form_layout->addRow("拔线后端", external_controller_type_edit);
     form_layout->addRow("外部控制器", external_controller_edit);
     form_layout->addRow("密钥", secret_edit);
     form_layout->addRow("套接字文件", unix_socket_edit);
     clash_layout->addLayout(form_layout);
     clash_layout->addWidget(test_btn, 0, Qt::AlignHCenter);
     clash_layout->addWidget(hint_label, 0, Qt::AlignHCenter);
+    auto *native_hint = new QLabel(
+        "原生 PF 模式不依赖 Clash；请先关闭 Clash/VPN 的 TUN。每次启动通常只需授权一次。", this);
+    native_hint->setStyleSheet("color: gray; font-size: 12px;");
+    native_hint->setWordWrap(true);
+    clash_layout->addWidget(native_hint);
     layout_outer->addWidget(clash_group);
 
     // ===== 偏好设置 =====
@@ -173,6 +184,10 @@ void SettingTab::setupVisibility() const {
         form_layout->setRowVisible(secret_edit, false);
         form_layout->setRowVisible(unix_socket_edit, true);
         unix_socket_edit->setText(QString::fromStdString(_config.unix_socket));
+    } else if (clash_config.external_controller_type == ExternalControllerType::NATIVE) {
+        form_layout->setRowVisible(external_controller_edit, false);
+        form_layout->setRowVisible(secret_edit, false);
+        form_layout->setRowVisible(unix_socket_edit, false);
     }
 }
 

--- a/src/skipper.cpp
+++ b/src/skipper.cpp
@@ -1,16 +1,93 @@
-#include <memory>
-
-#include <QDir>
-#include <QFile>
-#include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
-#include <QSettings>
+#include <QCoreApplication>
+#include <QFile>
+#include <QFileInfo>
+#include <QPointer>
+#include <QTimer>
 
-#include "yaml-cpp/yaml.h"
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <thread>
 
+#ifdef Q_OS_MACOS
+#include <Security/Authorization.h>
+#include <Security/AuthorizationTags.h>
+#endif
+
+#include "connection_selector.h"
+#include "local_connection.h"
 #include "skipper.h"
 
-using namespace std::string_literals;
+namespace {
+
+const char *controllerTypeName(const ExternalControllerType type) {
+    switch (type) {
+    case ExternalControllerType::TCPIP:
+        return "tcp";
+    case ExternalControllerType::UNIX_DOMAIN:
+        return "unix";
+    case ExternalControllerType::NATIVE:
+        return "native-pf";
+    case ExternalControllerType::NONE:
+        return "none";
+    }
+    return "unknown";
+}
+
+int jsonPort(const QJsonValue &value) {
+    bool ok = false;
+    const int port = value.isString() ? value.toString().toInt(&ok) : value.toInt(-1);
+    return value.isString() && !ok ? -1 : port;
+}
+
+void logConnectionScan(const std::shared_ptr<spdlog::logger> &logger, const quint64 skipId,
+                       const QJsonArray &connections) {
+    int directTcp = 0;
+    int knownGamePort = 0;
+    int hearthstoneOwned = 0;
+    int missingProcess = 0;
+
+    for (qsizetype index = 0; index < connections.size(); ++index) {
+        const QJsonObject connection = connections.at(index).toObject();
+        const QJsonObject metadata = connection.value("metadata").toObject();
+        const QString network = metadata.value("network").toString().toLower();
+        const QString host = metadata.value("host").toString();
+        const QString processPath = metadata.value("processPath").toString();
+        const QString process = metadata.value("process").toString();
+        const QString owner = processPath.isEmpty() ? process : processPath;
+        const int port = jsonPort(metadata.value("destinationPort"));
+        const bool isDirectTcp = host.isEmpty() && (network.isEmpty() || network == "tcp");
+        const bool isGamePort = port == 1119 || port == 3724;
+        const bool isHearthstone = owner.contains("hearthstone", Qt::CaseInsensitive);
+
+        directTcp += isDirectTcp ? 1 : 0;
+        knownGamePort += isGamePort ? 1 : 0;
+        hearthstoneOwned += isHearthstone ? 1 : 0;
+        missingProcess += owner.isEmpty() ? 1 : 0;
+
+        // Detailed rows are limited to relevant connections. This is enough
+        // to diagnose missing process attribution without dumping unrelated
+        // browsing destinations into a user-shared log.
+        if (isHearthstone || (isDirectTcp && (isGamePort || owner.isEmpty()))) {
+            SPDLOG_LOGGER_INFO(
+                logger,
+                "skip_id={} scan_row={} id={} owner={} network={} direct_ip={} source={}:{} destination={}:{} upload={} download={}",
+                skipId, index, connection.value("id").toString().toStdString(), owner.toStdString(),
+                network.toStdString(), host.isEmpty(), metadata.value("sourceIP").toString().toStdString(),
+                jsonPort(metadata.value("sourcePort")), metadata.value("destinationIP").toString().toStdString(), port,
+                connection.value("upload").toDouble(0), connection.value("download").toDouble(0));
+        }
+    }
+
+    SPDLOG_LOGGER_INFO(logger,
+                       "skip_id={} scan_summary total={} direct_tcp={} game_port={} hearthstone_owner={} "
+                       "missing_process={}",
+                       skipId, connections.size(), directTcp, knownGamePort, hearthstoneOwned, missingProcess);
+}
+
+} // namespace
 
 Skipper::Skipper(ConfigAwareQEasy *qeasy, QObject *parent)
     : QObject(parent), _qeasy(qeasy), _logger(spdlog::get("skipper")) {
@@ -19,18 +96,49 @@ Skipper::Skipper(ConfigAwareQEasy *qeasy, QObject *parent)
             [this](bool testSuccess, const std::string &message) { emit testFinished(testSuccess, message); });
 }
 
-Skipper::~Skipper() = default;
+Skipper::~Skipper() {
+#ifdef Q_OS_MACOS
+    if (_nativeAuthorization != nullptr) {
+        AuthorizationFree(static_cast<AuthorizationRef>(_nativeAuthorization), kAuthorizationFlagDefaults);
+        _nativeAuthorization = nullptr;
+    }
+#endif
+}
 
 void Skipper::skip() {
     if (_busy) {
-        SPDLOG_LOGGER_INFO(_logger, "skip() called while busy, ignoring");
+        SPDLOG_LOGGER_INFO(_logger, "skip_id={} duplicate click while busy, ignoring", _skipId);
         return;
     }
     _busy = true;
+    _getAttempts = 0;
+    ++_skipId;
+    _skipTimer.start();
+    const ClashConfig &currentConfig = _qeasy->config();
+    SPDLOG_LOGGER_INFO(_logger, "skip_id={} begin controller_type={} controller={} unix_socket={}", _skipId,
+                       controllerTypeName(currentConfig.external_controller_type), currentConfig.external_controller,
+                       currentConfig.unix_socket);
+    _logger->flush();
+    if (currentConfig.external_controller_type == ExternalControllerType::NATIVE) {
+        nativeDisconnect();
+        return;
+    }
     getConnection();
 }
 
-void Skipper::test() const {
+void Skipper::test() {
+    if (_qeasy->config().external_controller_type == ExternalControllerType::NATIVE) {
+#ifdef Q_OS_MACOS
+        const QFileInfo helper(nativeHelperPath());
+        const bool available = helper.isFile() && helper.isExecutable();
+        SPDLOG_LOGGER_INFO(_logger, "native_backend_test helper={} available={}",
+                           helper.absoluteFilePath().toStdString(), available);
+        emit testFinished(available, available ? "" : "原生辅助程序不存在或不可执行");
+#else
+        emit testFinished(false, "原生 PF 模式仅支持 macOS");
+#endif
+        return;
+    }
     _qeasy->test();
 }
 
@@ -43,59 +151,99 @@ void Skipper::setConfig(const ClashConfig &config) const {
 }
 
 void Skipper::getConnection() {
+    ++_getAttempts;
     const std::string url = _qeasy->config().connections();
+    SPDLOG_LOGGER_INFO(_logger, "skip_id={} scan attempt={}", _skipId, _getAttempts);
+    curl_easy_setopt(_qeasy->curl, CURLOPT_CUSTOMREQUEST, nullptr);
+    curl_easy_setopt(_qeasy->curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(_qeasy->curl, CURLOPT_URL, url.c_str());
+    if (!_qeasy->perform()) {
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} unable to start GET {}: HTTP client is already busy", _skipId,
+                            url);
+        finishSkip(false);
+        return;
+    }
     connect(_qeasy, &QCurlEasy::done, this, &Skipper::handleGetConnectionThenKill, Qt::SingleShotConnection);
-    _qeasy->perform();
 }
 
 void Skipper::handleGetConnectionThenKill(const QString &error, long code, const QByteArray &body) {
     const std::string url = _qeasy->config().connections();
     if (!error.isEmpty()) {
-        SPDLOG_LOGGER_ERROR(_logger, "GET {} failed: {}", url, error.toStdString());
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} GET {} failed: {}", _skipId, url, error.toStdString());
         _logger->flush();
-        _busy = false;
-        emit skipFinished(false);
+        finishSkip(false);
         return;
     }
     if (code / 100 != 2) {
-        SPDLOG_LOGGER_ERROR(_logger, "GET {} code={} body={}", url, code, body.toStdString());
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} GET {} code={} body={}", _skipId, url, code,
+                            body.toStdString());
         _logger->flush();
-        _busy = false;
-        emit skipFinished(false);
+        finishSkip(false);
         return;
     }
-    auto doc = QJsonDocument::fromJson(body);
-    if (!doc["connections"].isArray()) {
-        SPDLOG_LOGGER_WARN(_logger, "Failed to get connection, malformed json {}", body.toStdString());
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(body, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        SPDLOG_LOGGER_WARN(_logger, "skip_id={} malformed /connections response: error={} body={}", _skipId,
+                           parseError.errorString().toStdString(), body.toStdString());
         _logger->flush();
-        _busy = false;
-        emit skipFinished(false);
+        finishSkip(false);
         return;
     }
-    std::string connection_to_kill;
-    for (auto obj : doc["connections"].toArray()) {
-        if (obj.isObject() &&
-            obj.toObject()["metadata"].toObject()["processPath"].toString().endsWith(
-                "Hearthstone.app/Contents/MacOS/Hearthstone") &&
-            obj.toObject()["metadata"].toObject()["host"] == "") {
-            connection_to_kill = obj.toObject()["id"].toString().toStdString();
-            SPDLOG_LOGGER_INFO(_logger, "Connection to kill {}", connection_to_kill);
-            break;
+
+    const QJsonValue connections = doc.object().value("connections");
+    if (connections.isNull() || connections.isUndefined()) {
+        SPDLOG_LOGGER_INFO(_logger, "skip_id={} scan_result connections=null", _skipId);
+        retryGetConnection("controller currently reports no proxied connections");
+        return;
+    }
+    if (!connections.isArray()) {
+        SPDLOG_LOGGER_WARN(_logger,
+                           "skip_id={} malformed /connections response: 'connections' is not an array body={}",
+                           _skipId, body.toStdString());
+        finishSkip(false);
+        return;
+    }
+
+    const QJsonArray connectionArray = connections.toArray();
+    logConnectionScan(_logger, _skipId, connectionArray);
+    const QList<LocalTcpConnection> localConnections = hearthstoneTcpConnections();
+    for (const LocalTcpConnection &local : localConnections) {
+        if (local.destinationPort == 1119 || local.destinationPort == 3724) {
+            SPDLOG_LOGGER_INFO(_logger, "skip_id={} local_hearthstone_socket process={} source={}:{} destination={}:{}",
+                               _skipId, local.process.toStdString(), local.sourceIp.toStdString(), local.sourcePort,
+                               local.destinationIp.toStdString(), local.destinationPort);
         }
     }
-    if (connection_to_kill.empty()) {
-        SPDLOG_LOGGER_WARN(_logger, "No connection to kill");
-        _logger->flush();
-        _busy = false;
-        emit skipFinished(false);
+    SPDLOG_LOGGER_INFO(_logger, "skip_id={} local_hearthstone_socket_count={}", _skipId, localConnections.size());
+    const std::optional<TcpDestination> gameServer = hearthstoneGameServerDestination();
+    if (gameServer.has_value()) {
+        SPDLOG_LOGGER_INFO(_logger, "skip_id={} hearthstone_game_log_destination={}:{}", _skipId,
+                           gameServer->ip.toStdString(), gameServer->port);
+    } else {
+        SPDLOG_LOGGER_WARN(_logger, "skip_id={} hearthstone_game_log_destination=unavailable", _skipId);
+    }
+    const auto selected = selectHearthstoneConnection(connectionArray, localConnections, gameServer);
+    if (!selected.has_value()) {
+        retryGetConnection("no Hearthstone game-server connection found");
         return;
     }
-    const std::string url2 = _qeasy->config().kill_connection(connection_to_kill);
+    SPDLOG_LOGGER_INFO(_logger,
+                       "skip_id={} selected id={} process={} source={}:{} destination={}:{} traffic={} score={}", _skipId,
+                       selected->id.toStdString(), selected->process.toStdString(),
+                       selected->sourceIp.toStdString(), selected->sourcePort, selected->destinationIp.toStdString(),
+                       selected->destinationPort, selected->traffic,
+                       selected->score);
+    const std::string url2 = _qeasy->config().kill_connection(selected->id.toStdString());
     curl_easy_setopt(_qeasy->curl, CURLOPT_URL, url2.c_str());
     curl_easy_setopt(_qeasy->curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+    if (!_qeasy->perform()) {
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} unable to start DELETE {}: HTTP client is already busy", _skipId,
+                            url2);
+        finishSkip(false);
+        return;
+    }
     connect(_qeasy, &QCurlEasy::done, this, &Skipper::handleKillConnection, Qt::SingleShotConnection);
-    _qeasy->perform();
 }
 
 void Skipper::handleKillConnection(const QString &error, long code, const QByteArray &body) {
@@ -105,20 +253,176 @@ void Skipper::handleKillConnection(const QString &error, long code, const QByteA
     curl_easy_getinfo(_qeasy->curl, CURLINFO_EFFECTIVE_URL, &url);
 
     if (!error.isEmpty()) {
-        SPDLOG_LOGGER_ERROR(_logger, "DELETE {} failed: {}", url, error.toStdString());
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} DELETE {} failed: {}", _skipId, url, error.toStdString());
         _logger->flush();
-        _busy = false;
-        emit skipFinished(false);
+        finishSkip(false);
+        return;
+    }
+    // A connection disappearing between GET and DELETE is equivalent to the
+    // desired outcome: the client no longer owns that session socket.
+    if (code == 404 || code == 410) {
+        SPDLOG_LOGGER_INFO(_logger, "skip_id={} DELETE {} raced with connection close (code={})", _skipId, url,
+                           code);
+        finishSkip(true);
         return;
     }
     if (code / 100 != 2) {
-        SPDLOG_LOGGER_ERROR(_logger, "DELETE {} failed code={} body={}", url, code, body.toStdString());
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} DELETE {} failed code={} body={}", _skipId, url, code,
+                            body.toStdString());
         _logger->flush();
-        _busy = false;
-        emit skipFinished(false);
+        finishSkip(false);
         return;
     }
-    SPDLOG_LOGGER_INFO(_logger, "DELETE {}", url);
+    SPDLOG_LOGGER_INFO(_logger, "skip_id={} DELETE {} code={}", _skipId, url, code);
+    finishSkip(true);
+}
+
+void Skipper::retryGetConnection(const std::string &reason) {
+    constexpr int maxAttempts = 5;
+    constexpr int retryDelayMs = 200;
+    if (_getAttempts >= maxAttempts) {
+        SPDLOG_LOGGER_WARN(_logger, "skip_id={} {} after {} attempts", _skipId, reason, _getAttempts);
+        _logger->flush();
+        finishSkip(false);
+        return;
+    }
+    SPDLOG_LOGGER_INFO(_logger, "skip_id={} {}; retrying ({}/{})", _skipId, reason, _getAttempts, maxAttempts);
+    QTimer::singleShot(retryDelayMs, this, [this] {
+        if (_busy) {
+            getConnection();
+        }
+    });
+}
+
+void Skipper::finishSkip(const bool success) {
+    const qint64 elapsedMs = _skipTimer.isValid() ? _skipTimer.elapsed() : -1;
+    SPDLOG_LOGGER_INFO(_logger, "skip_id={} finish success={} attempts={} elapsed_ms={}", _skipId, success,
+                       _getAttempts, elapsedMs);
+    _logger->flush();
     _busy = false;
-    emit skipFinished(true);
+    emit skipFinished(success);
+}
+
+QString Skipper::nativeHelperPath() const {
+    return QCoreApplication::applicationDirPath() + "/../Helpers/skipper-native-helper";
+}
+
+void Skipper::nativeDisconnect() {
+#ifndef Q_OS_MACOS
+    SPDLOG_LOGGER_ERROR(_logger, "skip_id={} native PF backend is only available on macOS", _skipId);
+    finishSkip(false);
+#else
+    const std::optional<TcpDestination> gameServer = hearthstoneGameServerDestination();
+    if (!gameServer.has_value()) {
+        SPDLOG_LOGGER_WARN(_logger, "skip_id={} native game server unavailable in newest Hearthstone log", _skipId);
+        finishSkip(false);
+        return;
+    }
+    const QList<LocalTcpConnection> sockets = hearthstoneTcpConnections();
+    const auto socket = std::find_if(sockets.cbegin(), sockets.cend(), [&gameServer](const LocalTcpConnection &item) {
+        return item.destinationIp == gameServer->ip && item.destinationPort == gameServer->port;
+    });
+    if (socket == sockets.cend()) {
+        SPDLOG_LOGGER_WARN(_logger, "skip_id={} native game server {}:{} is not an established Hearthstone socket",
+                           _skipId, gameServer->ip.toStdString(), gameServer->port);
+        finishSkip(false);
+        return;
+    }
+    // 198.18.0.0/15 and Clash Verge's fdfe:dcba:9876::/48 are synthetic
+    // TUN addresses. PF cannot reliably target the game's real transport
+    // while another tunnel/proxy owns it, so native mode must fail closed.
+    const bool tunSource = socket->sourceIp.startsWith("198.18.") ||
+                           socket->sourceIp.startsWith("198.19.") ||
+                           socket->sourceIp.startsWith("fdfe:dcba:9876:", Qt::CaseInsensitive);
+    if (tunSource) {
+        SPDLOG_LOGGER_WARN(_logger,
+                           "skip_id={} native backend refused synthetic TUN source={}; disable Clash/VPN TUN first",
+                           _skipId, socket->sourceIp.toStdString());
+        finishSkip(false);
+        return;
+    }
+
+    const QString helperPath = nativeHelperPath();
+    const QFileInfo helper(helperPath);
+    if (!helper.isFile() || !helper.isExecutable()) {
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} native helper unavailable path={}", _skipId,
+                            helperPath.toStdString());
+        finishSkip(false);
+        return;
+    }
+
+    SPDLOG_LOGGER_INFO(_logger,
+                       "skip_id={} native selected process={} source={}:{} destination={}:{} helper={}", _skipId,
+                       socket->process.toStdString(), socket->sourceIp.toStdString(), socket->sourcePort,
+                       socket->destinationIp.toStdString(), socket->destinationPort, helperPath.toStdString());
+    AuthorizationRef authorization = static_cast<AuthorizationRef>(_nativeAuthorization);
+    if (authorization == nullptr) {
+        const OSStatus createStatus = AuthorizationCreate(nullptr, kAuthorizationEmptyEnvironment,
+                                                          kAuthorizationFlagDefaults, &authorization);
+        if (createStatus != errAuthorizationSuccess) {
+            SPDLOG_LOGGER_ERROR(_logger, "skip_id={} AuthorizationCreate failed status={}", _skipId, createStatus);
+            finishSkip(false);
+            return;
+        }
+        _nativeAuthorization = authorization;
+    }
+
+    AuthorizationItem executeItem{kAuthorizationRightExecute, 0, nullptr, 0};
+    AuthorizationRights rights{1, &executeItem};
+    const AuthorizationFlags flags = kAuthorizationFlagInteractionAllowed | kAuthorizationFlagExtendRights |
+                                     kAuthorizationFlagPreAuthorize;
+    const OSStatus rightsStatus = AuthorizationCopyRights(authorization, &rights, kAuthorizationEmptyEnvironment,
+                                                          flags, nullptr);
+    if (rightsStatus != errAuthorizationSuccess) {
+        SPDLOG_LOGGER_WARN(_logger, "skip_id={} native authorization denied status={}", _skipId, rightsStatus);
+        finishSkip(false);
+        return;
+    }
+
+    const QByteArray helperUtf8 = QFile::encodeName(helperPath);
+    const QByteArray addressUtf8 = gameServer->ip.toUtf8();
+    const QByteArray portUtf8 = QByteArray::number(gameServer->port);
+    QByteArray durationUtf8("1500");
+    std::array<char *, 5> arguments{
+        const_cast<char *>("disconnect"), const_cast<char *>(addressUtf8.constData()),
+        const_cast<char *>(portUtf8.constData()), durationUtf8.data(), nullptr,
+    };
+    FILE *communicationsPipe = nullptr;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    const OSStatus executeStatus = AuthorizationExecuteWithPrivileges(
+        authorization, helperUtf8.constData(), kAuthorizationFlagDefaults, arguments.data(), &communicationsPipe);
+#pragma clang diagnostic pop
+    if (executeStatus != errAuthorizationSuccess || communicationsPipe == nullptr) {
+        SPDLOG_LOGGER_ERROR(_logger, "skip_id={} native helper launch failed status={}", _skipId, executeStatus);
+        finishSkip(false);
+        return;
+    }
+
+    const quint64 operationSkipId = _skipId;
+    QPointer<Skipper> guard(this);
+    std::thread([guard, communicationsPipe, operationSkipId] {
+        QByteArray output;
+        std::array<char, 1024> buffer{};
+        size_t count = 0;
+        while ((count = std::fread(buffer.data(), 1, buffer.size(), communicationsPipe)) > 0) {
+            output.append(buffer.data(), static_cast<qsizetype>(count));
+        }
+        std::fclose(communicationsPipe);
+        QMetaObject::invokeMethod(
+            guard.data(),
+            [guard, output, operationSkipId] {
+                if (guard.isNull()) {
+                    return;
+                }
+                const bool success = output.contains("native disconnect completed");
+                SPDLOG_LOGGER_INFO(guard->_logger, "skip_id={} native helper finish success={} output={}",
+                                   operationSkipId, success, output.toStdString());
+                if (guard->_busy && guard->_skipId == operationSkipId) {
+                    guard->finishSkip(success);
+                }
+            },
+            Qt::QueuedConnection);
+    }).detach();
+#endif
 }

--- a/test/connection_selector_test.cpp
+++ b/test/connection_selector_test.cpp
@@ -1,0 +1,83 @@
+#include "connection_selector.h"
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <iostream>
+
+namespace {
+
+QJsonArray connections(const char *json) {
+    return QJsonDocument::fromJson(json).array();
+}
+
+bool expect(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "FAILED: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    QCoreApplication app(argc, argv);
+    bool ok = true;
+
+    const auto preferred = selectHearthstoneConnection(connections(R"([
+        {"id":"generic","upload":9000,"download":9000,"metadata":{"network":"tcp","host":"","processPath":"/Applications/Hearthstone.app/Contents/MacOS/Hearthstone","destinationIP":"1.1.1.1","destinationPort":"443"}},
+        {"id":"game","upload":1,"download":2,"metadata":{"network":"tcp","host":"","process":"Hearthstone","destinationIP":"2.2.2.2","destinationPort":"1119"}}
+    ])"));
+    ok &= expect(preferred.has_value() && preferred->id == "game", "known game port must be preferred");
+
+    const auto windows = selectHearthstoneConnection(connections(R"([
+        {"id":"win","metadata":{"network":"tcp","host":"","processPath":"C:\\Games\\Hearthstone.exe","destinationPort":3724}}
+    ])"));
+    ok &= expect(windows.has_value() && windows->id == "win", "Windows paths and numeric ports must match");
+
+    const auto busiest = selectHearthstoneConnection(connections(R"([
+        {"id":"low","upload":10,"download":20,"metadata":{"network":"tcp","host":"","process":"Hearthstone","destinationPort":"1119"}},
+        {"id":"high","upload":100,"download":200,"metadata":{"network":"tcp","host":"","process":"Hearthstone.exe","destinationPort":"1119"}}
+    ])"));
+    ok &= expect(busiest.has_value() && busiest->id == "high", "traffic must break equal-score ties");
+
+    const auto unsafe = selectHearthstoneConnection(connections(R"([
+        {"id":"domain","metadata":{"network":"tcp","host":"service.example","process":"Hearthstone","destinationPort":"1119"}},
+        {"id":"other","metadata":{"network":"tcp","host":"","process":"Other","destinationPort":"1119"}},
+        {"id":"udp","metadata":{"network":"udp","host":"","process":"Hearthstone","destinationPort":"1119"}}
+    ])"));
+    ok &= expect(!unsafe.has_value(), "domain, foreign-process, and UDP connections must be rejected");
+
+    const QList<LocalTcpConnection> localSockets{
+        {.process = "/Applications/Hearthstone/Hearthstone.app/Contents/MacOS/Hearthstone",
+         .sourceIp = "198.18.0.1",
+         .sourcePort = 60554,
+         .destinationIp = "116.62.121.9",
+         .destinationPort = 1119},
+    };
+    const auto localFallback = selectHearthstoneConnection(connections(R"([
+        {"id":"correct","upload":10,"download":20,"metadata":{"network":"tcp","host":"","sourceIP":"198.18.0.1","sourcePort":"60554","destinationIP":"116.62.121.9","destinationPort":"1119"}},
+        {"id":"same-target-wrong-owner","upload":9999,"download":9999,"metadata":{"network":"tcp","host":"","sourceIP":"198.18.0.1","sourcePort":"61156","destinationIP":"116.62.121.9","destinationPort":"1119"}}
+    ])"), localSockets);
+    ok &= expect(localFallback.has_value() && localFallback->id == "correct",
+                 "local source port must safely disambiguate missing Clash process metadata");
+
+    const QList<LocalTcpConnection> twoBlizzardSockets{
+        {.process = "Hearthstone", .sourcePort = 62075, .destinationIp = "118.31.18.157", .destinationPort = 1119},
+        {.process = "Hearthstone", .sourcePort = 62077, .destinationIp = "101.37.232.223", .destinationPort = 3724},
+    };
+    const auto gameLogExact = selectHearthstoneConnection(connections(R"([
+        {"id":"bnet-login","upload":900000,"download":900000,"metadata":{"network":"tcp","host":"","sourcePort":62075,"destinationIP":"118.31.18.157","destinationPort":1119}},
+        {"id":"actual-game","upload":1,"download":1,"metadata":{"network":"tcp","host":"","sourcePort":62077,"destinationIP":"101.37.232.223","destinationPort":3724}}
+    ])"), twoBlizzardSockets, TcpDestination{.ip = "101.37.232.223", .port = 3724});
+    ok &= expect(gameLogExact.has_value() && gameLogExact->id == "actual-game",
+                 "Hearthstone's game log endpoint must override traffic and port heuristics");
+
+    const auto safeFallback = selectHearthstoneConnection(connections(R"([
+        {"id":"bnet-login","upload":900000,"download":900000,"metadata":{"network":"tcp","host":"","process":"Hearthstone","destinationPort":1119}},
+        {"id":"game","upload":1,"download":1,"metadata":{"network":"tcp","host":"","process":"Hearthstone","destinationPort":3724}}
+    ])"));
+    ok &= expect(safeFallback.has_value() && safeFallback->id == "game",
+                 "port 3724 must be preferred over Battle.net service port 1119");
+
+    return ok ? 0 : 1;
+}

--- a/test/local_connection_probe.cpp
+++ b/test/local_connection_probe.cpp
@@ -1,0 +1,18 @@
+#include "local_connection.h"
+
+#include <QCoreApplication>
+#include <iostream>
+
+int main(int argc, char **argv) {
+    QCoreApplication app(argc, argv);
+    const QList<LocalTcpConnection> sockets = hearthstoneTcpConnections();
+    for (const LocalTcpConnection &socket : sockets) {
+        std::cout << socket.sourceIp.toStdString() << ':' << socket.sourcePort << " -> "
+                  << socket.destinationIp.toStdString() << ':' << socket.destinationPort << '\n';
+    }
+    const std::optional<TcpDestination> gameServer = hearthstoneGameServerDestination();
+    if (gameServer.has_value()) {
+        std::cout << "game-server " << gameServer->ip.toStdString() << ':' << gameServer->port << '\n';
+    }
+    return sockets.isEmpty() || !gameServer.has_value() ? 1 : 0;
+}

--- a/test/qcurl_test.cpp
+++ b/test/qcurl_test.cpp
@@ -14,8 +14,6 @@ int main(int argc, char *argv[]) {
     CURL *curl = curl_easy_init();
     // 创建 QCurlEasy 对象，这会自动添加到 multi handle
     QCurlEasy qcurl_easy =  QCurlEasy(curl);
-    qcurl_easy.perform();
-
     // 设置 URL
     curl_easy_setopt(curl, CURLOPT_URL, "https://google.com");
 
@@ -40,10 +38,13 @@ int main(int argc, char *argv[]) {
         app.quit();
     });
 
+    if (!qcurl_easy.perform()) {
+        qDebug() << "Unable to start request";
+        return 1;
+    }
+
     qDebug() << "Request created, waiting for response...";
 
     // 进入 Qt 事件循环，等待异步响应
     return QCoreApplication::exec();
 }
-
-


### PR DESCRIPTION
## What changed

- add a macOS native PF disconnect backend that does not require Clash
- select the live Hearthstone game socket from GameNetLogger and libproc data
- make Clash mode prefer the exact game connection and harden request handling
- add structured per-attempt diagnostics and startup logging
- add connection-selection tests, a local socket probe, and native-mode design notes

## Why

The previous implementation could target the wrong Blizzard connection, silently ignore repeated clicks, and depended entirely on Clash. The first native PF prototype also kept the block rule active long enough to reject Hearthstone's immediate reconnect, leaving the client stuck on “正在重新连接”.

## Impact

Native mode now sends a reset only to ACK-bearing packets on the existing game connection, permits the following SYN immediately, and removes its private PF anchor as soon as a matching packet is observed. It rejects Clash/VPN synthetic TUN addresses instead of claiming a successful native disconnect.

Native mode still needs macOS administrator authorization. The current Authorization Services cache is process-scoped; persistent password-free operation across app launches requires a separately installed and signed privileged helper.

## Validation

- PF IPv4 and IPv6 rule syntax checked with `pfctl -vnf -`
- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure` (2/2 passed)
- packaged app passed `codesign --verify --deep --strict`
